### PR TITLE
Feat/card

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,15 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // ParameterObject
+    implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'
+
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/io/rednotice/card/controller/CardController.java
+++ b/src/main/java/io/rednotice/card/controller/CardController.java
@@ -1,0 +1,46 @@
+package io.rednotice.card.controller;
+
+import io.rednotice.card.dto.request.*;
+import io.rednotice.card.dto.response.CardManagerResponse;
+import io.rednotice.card.dto.response.CardResponse;
+import io.rednotice.card.dto.CardSearchDto;
+import io.rednotice.card.service.CardService;
+import io.rednotice.card.dto.request.CardManagerRequest;
+import io.rednotice.common.AuthUser;
+import io.rednotice.common.apipayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/cards")
+public class CardController {
+    private final CardService cardService;
+
+    @PostMapping
+    public ApiResponse<CardResponse> saveCard(@AuthenticationPrincipal AuthUser authUser,
+                                              @RequestBody CardSaveRequest cardSaveRequest) {
+        return ApiResponse.ok(cardService.saveCard(authUser, cardSaveRequest));
+    }
+
+    @PostMapping("/{cardId}/managers")
+    public ApiResponse<CardManagerResponse> addCardManager(@AuthenticationPrincipal AuthUser authUser,
+                                                           @PathVariable Long cardId,
+                                                           @RequestBody CardManagerRequest cardManagerRequest) {
+        return ApiResponse.ok(cardService.addManager(authUser, cardId, cardManagerRequest));
+    }
+
+
+    @DeleteMapping("/{cardId}")
+    public ApiResponse<String> deleteCard(@AuthenticationPrincipal AuthUser authUser,
+                                        @PathVariable Long cardId,
+                                        @RequestBody CardDeleteRequest cardDeleteRequest) {
+        cardService.deleteCard(authUser, cardId, cardDeleteRequest);
+        return ApiResponse.ok("카드가 삭제되었습니다.");
+    }
+
+    // 카드 순서, list 이동은 일단 보류
+}

--- a/src/main/java/io/rednotice/card/controller/CardController.java
+++ b/src/main/java/io/rednotice/card/controller/CardController.java
@@ -33,6 +33,12 @@ public class CardController {
         return ApiResponse.ok(cardService.addManager(authUser, cardId, cardManagerRequest));
     }
 
+    @GetMapping
+    public ApiResponse<Page<CardSearchDto>> searchCards(@ParameterObject CardPageRequest cardPageRequest,
+                                                        @ParameterObject CardSearchRequest cardSearchRequest) {
+        return ApiResponse.ok(cardService.searchCards(cardPageRequest, cardSearchRequest));
+    }
+
 
     @DeleteMapping("/{cardId}")
     public ApiResponse<String> deleteCard(@AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/io/rednotice/card/controller/CardController.java
+++ b/src/main/java/io/rednotice/card/controller/CardController.java
@@ -1,6 +1,7 @@
 package io.rednotice.card.controller;
 
 import io.rednotice.card.dto.request.*;
+import io.rednotice.card.dto.response.CardDetailResponse;
 import io.rednotice.card.dto.response.CardManagerResponse;
 import io.rednotice.card.dto.response.CardResponse;
 import io.rednotice.card.dto.CardSearchDto;
@@ -39,6 +40,17 @@ public class CardController {
         return ApiResponse.ok(cardService.searchCards(cardPageRequest, cardSearchRequest));
     }
 
+    @GetMapping("/{cardId}")
+    public ApiResponse<CardDetailResponse> getCard(@PathVariable Long cardId) {
+        return ApiResponse.ok(cardService.getCard(cardId));
+    }
+
+    @PatchMapping("/{cardId}")
+    public ApiResponse<CardResponse> updateCard(@AuthenticationPrincipal AuthUser authUser,
+                                                @PathVariable Long cardId,
+                                                @RequestBody CardUpdateRequest cardUpdateRequest) {
+        return ApiResponse.ok(cardService.updateCard(authUser, cardId, cardUpdateRequest));
+    }
 
     @DeleteMapping("/{cardId}")
     public ApiResponse<String> deleteCard(@AuthenticationPrincipal AuthUser authUser,

--- a/src/main/java/io/rednotice/card/controller/CardController.java
+++ b/src/main/java/io/rednotice/card/controller/CardController.java
@@ -31,7 +31,7 @@ public class CardController {
     public ApiResponse<CardManagerResponse> addCardManager(@AuthenticationPrincipal AuthUser authUser,
                                                            @PathVariable Long cardId,
                                                            @RequestBody CardManagerRequest cardManagerRequest) {
-        return ApiResponse.ok(cardService.addManager(authUser, cardId, cardManagerRequest));
+        return ApiResponse.ok(cardService.changeManager(authUser, cardId, cardManagerRequest));
     }
 
     @GetMapping

--- a/src/main/java/io/rednotice/card/dto/CardSearchDto.java
+++ b/src/main/java/io/rednotice/card/dto/CardSearchDto.java
@@ -1,0 +1,30 @@
+package io.rednotice.card.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+public class CardSearchDto {   // 카드 검색 시 반환 DTO
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final LocalDate dueDate;
+    private final Long boardId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    @QueryProjection
+    public CardSearchDto(Long id, String title, String description, LocalDate dueDate, Long boardId, LocalDateTime createdAt, LocalDateTime modifiedAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+        this.boardId = boardId;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+    }
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardDeleteRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardDeleteRequest.java
@@ -1,0 +1,10 @@
+package io.rednotice.card.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CardDeleteRequest {
+    private Long workSpaceId;
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardManagerRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardManagerRequest.java
@@ -1,0 +1,13 @@
+package io.rednotice.card.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardManagerRequest {
+    private Long managerId;
+    private Long workSpaceId;   // 소속 workSpace
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardPageRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardPageRequest.java
@@ -1,0 +1,12 @@
+package io.rednotice.card.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// ParameterObject
+@Getter
+@AllArgsConstructor
+public class CardPageRequest {
+    private int page = 0;
+    private int size = 10;
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardSaveRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardSaveRequest.java
@@ -1,0 +1,22 @@
+package io.rednotice.card.dto.request;
+
+import io.rednotice.card.entity.Card;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardSaveRequest {
+    private String title;
+    private String description;
+    private LocalDate dueDate;
+    private int seq;
+    private Long workSpaceId;   // 소속 workSpace
+    private Long boardId;   // 소속 board
+    private Long listId;    // 소속 list
+
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardSearchRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardSearchRequest.java
@@ -1,0 +1,17 @@
+package io.rednotice.card.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+// ParameterObject
+@Getter
+@AllArgsConstructor
+public class CardSearchRequest {
+    private String title;
+    private String description;
+    private LocalDate dueDate;
+    private String managerName;
+    private Long boardId;
+}

--- a/src/main/java/io/rednotice/card/dto/request/CardUpdateRequest.java
+++ b/src/main/java/io/rednotice/card/dto/request/CardUpdateRequest.java
@@ -1,0 +1,16 @@
+package io.rednotice.card.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CardUpdateRequest {
+    private String title;
+    private String description;
+    private LocalDate dueDate;
+    private Long workSpaceId;   // 소속 workSpace
+}

--- a/src/main/java/io/rednotice/card/dto/response/CardDetailResponse.java
+++ b/src/main/java/io/rednotice/card/dto/response/CardDetailResponse.java
@@ -24,7 +24,7 @@ public class CardDetailResponse {   // 카드 단건 조회 시 반환 DTO
     // 댓글 구현완료되면 댓글 Dto 추가(댓글 작성자, 작성 내용, 날짜 ...)
     // 이때 batchsize 얼마나 할 것인지 확정하기
 
-    public static CardDetailResponse of(Card card, User user) {
+    public static CardDetailResponse of(Card card) {
         return new CardDetailResponse(
                 card.getId(),
                 card.getTitle(),
@@ -32,7 +32,7 @@ public class CardDetailResponse {   // 카드 단건 조회 시 반환 DTO
                 card.getDueDate(),
                 card.getSeq(),
                 card.getViews(),
-                new UserDto(user.getId(), user.getEmail(), user.getUsername()),
+                new UserDto(card.getUser().getId(), card.getUser().getEmail(), card.getUser().getUsername()),
                 card.getCreatedAt(),
                 card.getModifiedAt()
                 // 댓글 dto 추가

--- a/src/main/java/io/rednotice/card/dto/response/CardDetailResponse.java
+++ b/src/main/java/io/rednotice/card/dto/response/CardDetailResponse.java
@@ -1,0 +1,41 @@
+package io.rednotice.card.dto.response;
+
+import io.rednotice.card.entity.Card;
+import io.rednotice.user.dto.UserDto;
+import io.rednotice.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CardDetailResponse {   // 카드 단건 조회 시 반환 DTO
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final LocalDate dueDate;
+    private final int seq;
+    private final int views;
+    private final UserDto userDto;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+    // 댓글 구현완료되면 댓글 Dto 추가(댓글 작성자, 작성 내용, 날짜 ...)
+    // 이때 batchsize 얼마나 할 것인지 확정하기
+
+    public static CardDetailResponse of(Card card, User user) {
+        return new CardDetailResponse(
+                card.getId(),
+                card.getTitle(),
+                card.getDescription(),
+                card.getDueDate(),
+                card.getSeq(),
+                card.getViews(),
+                new UserDto(user.getId(), user.getEmail(), user.getUsername()),
+                card.getCreatedAt(),
+                card.getModifiedAt()
+                // 댓글 dto 추가
+        );
+    }
+}

--- a/src/main/java/io/rednotice/card/dto/response/CardManagerResponse.java
+++ b/src/main/java/io/rednotice/card/dto/response/CardManagerResponse.java
@@ -1,0 +1,11 @@
+package io.rednotice.card.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CardManagerResponse {
+    private final Long cardId;
+    private final Long managerUserId;
+}

--- a/src/main/java/io/rednotice/card/dto/response/CardResponse.java
+++ b/src/main/java/io/rednotice/card/dto/response/CardResponse.java
@@ -22,7 +22,7 @@ public class CardResponse {
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
 
-    public static CardResponse of(Card card, User user) {
+    public static CardResponse of(Card card) {
         return new CardResponse(
                 card.getId(),
                 card.getTitle(),
@@ -30,7 +30,7 @@ public class CardResponse {
                 card.getDueDate(),
                 card.getSeq(),
                 card.getViews(),
-                new UserDto(user.getId(), user.getEmail(), user.getUsername()),
+                new UserDto(card.getUser().getId(), card.getUser().getEmail(), card.getUser().getUsername()),
                 card.getCreatedAt(),
                 card.getModifiedAt()
         );

--- a/src/main/java/io/rednotice/card/dto/response/CardResponse.java
+++ b/src/main/java/io/rednotice/card/dto/response/CardResponse.java
@@ -1,0 +1,38 @@
+package io.rednotice.card.dto.response;
+
+import io.rednotice.card.entity.Card;
+import io.rednotice.user.dto.UserDto;
+import io.rednotice.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CardResponse {
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final LocalDate dueDate;
+    private final int seq;
+    private final int views;
+    private final UserDto userDto;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+
+    public static CardResponse of(Card card, User user) {
+        return new CardResponse(
+                card.getId(),
+                card.getTitle(),
+                card.getDescription(),
+                card.getDueDate(),
+                card.getSeq(),
+                card.getViews(),
+                new UserDto(user.getId(), user.getEmail(), user.getUsername()),
+                card.getCreatedAt(),
+                card.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/io/rednotice/card/entity/Card.java
+++ b/src/main/java/io/rednotice/card/entity/Card.java
@@ -66,9 +66,15 @@ public class Card extends Timestamped {
     }
 
     public void updateCard(String title, String description, LocalDate dueDate) {
-        this.title = title;
-        this.description = description;
-        this.dueDate = dueDate;
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (dueDate != null) {
+            this.dueDate = dueDate;
+        }
     }
 
     public void changeSeq(int seq) {

--- a/src/main/java/io/rednotice/card/entity/Card.java
+++ b/src/main/java/io/rednotice/card/entity/Card.java
@@ -1,0 +1,85 @@
+package io.rednotice.card.entity;
+
+import io.rednotice.board.entity.Board;
+import io.rednotice.common.Timestamped;
+import io.rednotice.list.entity.Lists;
+import io.rednotice.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "card")
+@DynamicInsert
+@NoArgsConstructor
+public class Card extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private String title;
+
+    @Column(length = 255, nullable = false)
+    private String description;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(nullable = false)
+    private int seq;
+
+    @ColumnDefault("0")
+    private int views;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "list_id", nullable = false)
+    private Lists list;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(referencedColumnName = "id", name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(referencedColumnName = "id", name = "manager_id", nullable = false)
+    private User manager;
+
+    public Card(String title, String description, LocalDate dueDate, int seq, Board board, Lists list, User user) {
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+        this.seq = seq;
+        this.board = board;
+        this.list = list;
+        this.user = user;
+        this.manager = user;
+    }
+
+    public void updateCard(String title, String description, LocalDate dueDate) {
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+    }
+
+    public void changeSeq(int seq) {
+        this.seq = seq;
+    }
+
+    public void updateViews(int views){
+        this.views = views;
+    }
+
+    public void changeManager(User user) {
+        this.manager = user;
+    }
+}

--- a/src/main/java/io/rednotice/card/repository/CardQueryDslRepository.java
+++ b/src/main/java/io/rednotice/card/repository/CardQueryDslRepository.java
@@ -1,0 +1,17 @@
+package io.rednotice.card.repository;
+
+import io.rednotice.card.dto.CardSearchDto;
+import io.rednotice.card.dto.request.CardSearchRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface CardQueryDslRepository {
+    Page<CardSearchDto> search(String title,
+                               String description,
+                               LocalDate dueDate,
+                               String managerName,
+                               Long boardId,
+                               Pageable pageable);
+}

--- a/src/main/java/io/rednotice/card/repository/CardQueryDslRepositoryImpl.java
+++ b/src/main/java/io/rednotice/card/repository/CardQueryDslRepositoryImpl.java
@@ -1,0 +1,99 @@
+package io.rednotice.card.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.rednotice.card.dto.CardSearchDto;
+import io.rednotice.card.dto.QCardSearchDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import static io.rednotice.board.entity.QBoard.board;
+import static io.rednotice.card.entity.QCard.card;
+import static io.rednotice.list.entity.QLists.lists;
+import static io.rednotice.user.entity.QUser.user;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CardQueryDslRepositoryImpl implements CardQueryDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CardSearchDto> search(String title,
+                                      String description,
+                                      LocalDate dueDate,
+                                      String managerName,
+                                      Long boardId,
+                                      Pageable pageable) {
+        List<CardSearchDto> results = queryFactory
+                .select(
+                    new QCardSearchDto(
+                            card.id,
+                            card.title,
+                            card.description,
+                            card.dueDate,
+                            card.board.id,
+                            card.createdAt,
+                            card.modifiedAt
+                    )
+                )
+                .from(card)
+                .leftJoin(card.board, board)
+                .leftJoin(card.list, lists)
+                .leftJoin(card.user, user)
+                .where(
+                        titleContains(title),
+                        descriptionContains(description),
+                        dueDateIsEq(dueDate),
+                        managerNameIsEq(managerName),
+                        boardIdIsEq(boardId)
+                )
+                .groupBy(card.id)
+                .orderBy(card.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(Wildcard.count)
+                .from(card)
+                .where(
+                        titleContains(title),
+                        descriptionContains(description),
+                        dueDateIsEq(dueDate),
+                        managerNameIsEq(managerName),
+                        boardIdIsEq(boardId)
+                ).fetchOne();
+
+        return new PageImpl<>(results, pageable, totalCount);
+    }
+
+
+    private BooleanExpression titleContains(String title) {
+        return StringUtils.hasText(title) ? card.title.contains(title) : null;
+    }
+
+    private BooleanExpression descriptionContains(String description) {
+        return StringUtils.hasText(description) ? card.description.contains(description) : null;
+    }
+
+    private BooleanExpression dueDateIsEq(LocalDate dueDate) {
+        return dueDate != null ? card.dueDate.eq(dueDate) : null;
+    }
+
+    private BooleanExpression managerNameIsEq(String managerName) {
+        return StringUtils.hasText(managerName) ? card.manager.username.eq(managerName) : null;
+    }
+
+    private BooleanExpression boardIdIsEq(Long boardId) {
+        return card.board != null ? card.board.id.eq(boardId) : null;
+    }
+
+}

--- a/src/main/java/io/rednotice/card/repository/CardRepository.java
+++ b/src/main/java/io/rednotice/card/repository/CardRepository.java
@@ -1,0 +1,17 @@
+package io.rednotice.card.repository;
+
+import io.rednotice.card.entity.Card;
+import io.rednotice.common.apipayload.status.ErrorStatus;
+import io.rednotice.common.exception.ApiException;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CardRepository extends JpaRepository<Card, Long>{
+
+    default Card getCardById(Long cardId) {
+        return findById(cardId).orElseThrow(
+                () -> new ApiException(ErrorStatus._NOT_FOUND_CARD)
+        );
+    }
+}

--- a/src/main/java/io/rednotice/card/repository/CardRepository.java
+++ b/src/main/java/io/rednotice/card/repository/CardRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CardRepository extends JpaRepository<Card, Long>{
+public interface CardRepository extends JpaRepository<Card, Long>, CardQueryDslRepository{
 
     default Card getCardById(Long cardId) {
         return findById(cardId).orElseThrow(

--- a/src/main/java/io/rednotice/card/service/CardService.java
+++ b/src/main/java/io/rednotice/card/service/CardService.java
@@ -2,6 +2,7 @@ package io.rednotice.card.service;
 
 import io.rednotice.board.entity.Board;
 import io.rednotice.card.dto.request.*;
+import io.rednotice.card.dto.response.CardDetailResponse;
 import io.rednotice.card.dto.response.CardManagerResponse;
 import io.rednotice.card.dto.response.CardResponse;
 import io.rednotice.card.dto.CardSearchDto;
@@ -77,6 +78,10 @@ public class CardService {
         );
     }
 
+    public CardDetailResponse getCard(Long cardId) {
+        Card card = cardRepository.getCardById(cardId);
+        return CardDetailResponse.of(card);
+    }
 
     @Transactional
     public void deleteCard(AuthUser authUser, Long cardId, CardDeleteRequest deleteRequest) {

--- a/src/main/java/io/rednotice/card/service/CardService.java
+++ b/src/main/java/io/rednotice/card/service/CardService.java
@@ -1,0 +1,81 @@
+package io.rednotice.card.service;
+
+import io.rednotice.board.entity.Board;
+import io.rednotice.card.dto.request.*;
+import io.rednotice.card.dto.response.CardManagerResponse;
+import io.rednotice.card.dto.response.CardResponse;
+import io.rednotice.card.dto.CardSearchDto;
+import io.rednotice.card.entity.Card;
+import io.rednotice.card.repository.CardRepository;
+import io.rednotice.common.AuthUser;
+import io.rednotice.common.apipayload.status.ErrorStatus;
+import io.rednotice.common.exception.ApiException;
+import io.rednotice.list.entity.Lists;
+import io.rednotice.member.repository.MemberRepository;
+import io.rednotice.user.entity.User;
+import io.rednotice.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CardService {
+    private final CardRepository cardRepository;
+    private final UserRepository userRepository;
+    private final MemberRepository memberRepository;
+//    private final ListRepository listRepository;
+//    private final BoardRepository boardRepository;
+
+
+    @Transactional
+    public CardResponse saveCard(AuthUser authUser, CardSaveRequest saveRequest) {
+        checkMemberRole(authUser.getId(), saveRequest.getWorkSpaceId());
+
+        Board board = new Board();  // 임시 Board 객체(repo 구현되면 수정!)
+        Lists list = new Lists();   // 임시 Lists 객체(repo 구현되면 수정!)
+        User user = userRepository.getUserById(authUser.getId());
+        Card card = new Card(
+                saveRequest.getTitle(),
+                saveRequest.getDescription(),
+                saveRequest.getDueDate(),
+                saveRequest.getSeq(),
+                board,
+                list,
+                user
+        );
+        Card saveCard = cardRepository.save(card);
+
+        return CardResponse.of(saveCard, user);
+    }
+
+    @Transactional
+    public CardManagerResponse addManager(AuthUser authUser, Long cardId, CardManagerRequest managerRequest) {
+        checkMemberRole(authUser.getId(), managerRequest.getWorkSpaceId());
+
+        User manager = userRepository.getUserById(managerRequest.getManagerId());
+        Card card = cardRepository.getCardById(cardId);
+        card.changeManager(manager);
+
+        return new CardManagerResponse(cardId, manager.getId());
+    }
+
+
+    @Transactional
+    public void deleteCard(AuthUser authUser, Long cardId, CardDeleteRequest deleteRequest) {
+        checkMemberRole(authUser.getId(), deleteRequest.getWorkSpaceId());
+        cardRepository.deleteById(cardId);
+    }
+
+    private void checkMemberRole(Long userId, Long workSpaceId) {
+        // 읽기 전용 역할인 경우 예외 발생
+        if (memberRepository.findByUserIdAndWorkSpaceId(userId, workSpaceId) == null) {
+            throw new ApiException(ErrorStatus._READ_ONLY_ROLE);
+        }
+    }
+}

--- a/src/main/java/io/rednotice/card/service/CardService.java
+++ b/src/main/java/io/rednotice/card/service/CardService.java
@@ -65,6 +65,18 @@ public class CardService {
         return new CardManagerResponse(cardId, manager.getId());
     }
 
+    public Page<CardSearchDto> searchCards(CardPageRequest cardPageRequest, CardSearchRequest searchRequest) {
+        Pageable pageable = PageRequest.of(cardPageRequest.getPage(), cardPageRequest.getSize());
+        return cardRepository.search(
+                searchRequest.getTitle(),
+                searchRequest.getDescription(),
+                searchRequest.getDueDate(),
+                searchRequest.getManagerName(),
+                searchRequest.getBoardId(),
+                pageable
+        );
+    }
+
 
     @Transactional
     public void deleteCard(AuthUser authUser, Long cardId, CardDeleteRequest deleteRequest) {

--- a/src/main/java/io/rednotice/common/apipayload/status/ErrorStatus.java
+++ b/src/main/java/io/rednotice/common/apipayload/status/ErrorStatus.java
@@ -15,7 +15,13 @@ public enum ErrorStatus implements BaseCode {
     _NOT_FOUND_(HttpStatus.NOT_FOUND, "404", "존재하지 않은 유저입니다"),
 
     // workspace
-    _NOT_FOUND_WORKSPACE(HttpStatus.NOT_FOUND, "404", "존재하지 않은 워크스페이스입니다");
+    _NOT_FOUND_WORKSPACE(HttpStatus.NOT_FOUND, "404", "존재하지 않은 워크스페이스입니다"),
+
+    // member
+    _READ_ONLY_ROLE(HttpStatus.FORBIDDEN, "403", "읽기 전용 권한으로 인해 카드 생성/수정/삭제가 불가능합니다"),
+
+    // card
+    _NOT_FOUND_CARD(HttpStatus.NOT_FOUND, "404", "존재하지 않는 카드입니다");
 
     private HttpStatus httpStatus;
     private String statusCode;

--- a/src/main/java/io/rednotice/config/JPAConfiguration.java
+++ b/src/main/java/io/rednotice/config/JPAConfiguration.java
@@ -1,0 +1,19 @@
+package io.rednotice.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/io/rednotice/member/repository/MemberRepository.java
+++ b/src/main/java/io/rednotice/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByUserAndWorkSpace(User user, WorkSpace workSpace);
+    Member findByUserIdAndWorkSpaceId(Long userId, Long workSpaceId);
 }

--- a/src/main/java/io/rednotice/member/repository/MemberRepository.java
+++ b/src/main/java/io/rednotice/member/repository/MemberRepository.java
@@ -1,11 +1,20 @@
 package io.rednotice.member.repository;
 
+import io.rednotice.common.apipayload.status.ErrorStatus;
+import io.rednotice.common.exception.ApiException;
 import io.rednotice.member.entity.Member;
 import io.rednotice.user.entity.User;
 import io.rednotice.workspace.entity.WorkSpace;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByUserAndWorkSpace(User user, WorkSpace workSpace);
-    Member findByUserIdAndWorkSpaceId(Long userId, Long workSpaceId);
+    Optional<Member> findByUserIdAndWorkSpaceId(Long userId, Long workSpaceId);
+
+    default Member getMember(Long userId, Long workSpaceId) {
+        return findByUserIdAndWorkSpaceId(userId, workSpaceId).orElseThrow(
+                () -> new ApiException(ErrorStatus._NOT_FOUND_WORKSPACE));
+    }
 }

--- a/src/main/java/io/rednotice/user/dto/UserDto.java
+++ b/src/main/java/io/rednotice/user/dto/UserDto.java
@@ -1,0 +1,14 @@
+package io.rednotice.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    private Long id;
+    private String email;
+    private String name;
+}

--- a/src/main/java/io/rednotice/user/repository/UserRepository.java
+++ b/src/main/java/io/rednotice/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package io.rednotice.user.repository;
 
+import io.rednotice.common.apipayload.status.ErrorStatus;
+import io.rednotice.common.exception.ApiException;
 import io.rednotice.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +10,10 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    default User getUserById(Long memberId) {
+        return findById(memberId).orElseThrow(
+                () -> new ApiException(ErrorStatus._NOT_FOUND_USER)
+        );
+    }
 }


### PR DESCRIPTION
<변경사항>

- 원래 manager 테이블이 따로 존재하고, card 테이블과 다대일 연관관계를 맺었으나 로직이 복잡해지는 관계로 일대일 관계로 수정되었습니다.
- 따라서 manager 테이블은 삭제되었고 card 테이블에 manager_id가 추가되어 담당 user의 id를 가지게 됩니다.
- 코드에서는 Manager 엔티티가 제거되고, Card 엔티티에서 User 엔티티를 두번 참조하게 되었습니다.(user_id, manager_id)

<추가사항>

- id로 유저 조회 및 예외처리하는 method가 여러 도메인의 service에서 반복되어 UserRepository의 default method로 추가했습니다.
- 해당 메서드를 Repository에서 호출하여 사용하시면 편할 것 같습니다.